### PR TITLE
Swap default values of 'base' and 'base_color' parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,8 +219,8 @@ Rainbow-like iridescence effects occur, due to interference, when a thin refract
 
 Name                       | Type  | Default | Description
 ---------------------------|-------|---------|------------
-**`base`**                 | float | `0.8`   | scalar multiplier to **`base_color`**
-**`base_color`**           | color | `1,1,1` | reflection color at normal incidence (i.e. surface seen from straight up)
+**`base`**                 | float | `1`     | scalar multiplier to **`base_color`**
+**`base_color`**           | color | `0.8,0.8,0.8` | reflection color at normal incidence (i.e. surface seen from straight up)
 **`specular`**             | float | `1`     | scalar multiplier to **`specular_color`**
 **`specular_color`**       | color | `1,1,1` | reflection color at grazing incidence (i.e. around silhouettes)
 **`specular_roughness`**   | float | `0.2`   | reflection roughness; squared internally before passed to the BSDF in order to achieve a more uniform roughness look over the parameter range


### PR DESCRIPTION
Currently, we have the defaults `base = 0.8` and `base_color = (1, 1, 1)`. There has been feedback that users find themselves to changing `base` to 1 after connecting `base_color` to a texture. This is such a common use case that it's better to swap the two defaults and avoid having to adjust `base` every time.